### PR TITLE
Incorporate cosmos particle system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -125,7 +125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
 dependencies = [
  "android-properties",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cc",
  "cesu8",
  "jni",
@@ -147,9 +147,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_system_properties"
@@ -440,7 +440,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "blake3",
  "crossbeam-channel",
  "derive_more",
@@ -539,7 +539,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "derive_more",
  "nonmax",
  "radsort",
@@ -586,7 +586,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "concurrent-queue",
  "derive_more",
  "disqualified",
@@ -728,7 +728,7 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
  "futures-lite",
@@ -857,7 +857,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
  "hexasphere",
@@ -893,7 +893,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
  "fixedbitset 0.5.7",
@@ -1067,7 +1067,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "derive_more",
  "fixedbitset 0.5.7",
@@ -1289,7 +1289,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -1341,25 +1341,24 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
+checksum = "675f87afced0413c9bb02843499dbbd3882a237645883f71a2b59644a6d2f753"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "memmap2",
 ]
 
 [[package]]
@@ -1398,9 +1397,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -1430,9 +1429,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calloop"
@@ -1440,7 +1439,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "log",
  "polling",
  "rustix",
@@ -1450,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -1677,7 +1676,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "fontdb",
  "log",
  "rangemap",
@@ -1926,9 +1925,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
  "typeid",
@@ -2282,7 +2281,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "gpu-alloc-types",
 ]
 
@@ -2292,7 +2291,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2313,7 +2312,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf29e94d6d243368b7a56caa16bc213e4f9f8ed38c4d9557069527b5d5281ca"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "gpu-descriptor-types",
  "hashbrown 0.15.2",
 ]
@@ -2324,7 +2323,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2435,7 +2434,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "inotify-sys",
  "libc",
 ]
@@ -2476,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -2592,9 +2591,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.10",
 ]
 
 [[package]]
@@ -2683,7 +2682,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block",
  "core-graphics-types",
  "foreign-types",
@@ -2716,7 +2715,7 @@ checksum = "364f94bc34f61332abebe8cad6f6cd82a5b65cff22c828d05d0968911462ca4f"
 dependencies = [
  "arrayvec",
  "bit-set 0.8.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg_aliases 0.1.1",
  "codespan-reporting",
  "hexf-parse",
@@ -2756,7 +2755,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys 0.5.0+25.2.9519653",
@@ -2770,7 +2769,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -2809,7 +2808,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -2923,7 +2922,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "libc",
  "objc2",
@@ -2939,7 +2938,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -2963,7 +2962,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3005,7 +3004,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "dispatch",
  "libc",
@@ -3030,7 +3029,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3042,7 +3041,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -3065,7 +3064,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3097,7 +3096,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-core-location",
@@ -3191,7 +3190,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.10",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3233,18 +3232,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3270,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -3328,9 +3327,9 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3347,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -3362,9 +3361,9 @@ checksum = "afbdc74edc00b6f6a218ca6a5364d6226a259d4b8ea1af4a0ea063f27e179f4d"
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -3393,8 +3392,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.2",
- "zerocopy 0.8.20",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.22",
 ]
 
 [[package]]
@@ -3414,7 +3413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.2",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3428,12 +3427,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a509b1a2ffbe92afab0e55c8fd99dea1c280e8171bd2d88682bb20bc41cbc2c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -3511,11 +3509,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3586,7 +3584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "serde",
  "serde_derive",
 ]
@@ -3599,9 +3597,10 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rs_physics"
-version = "0.1.6"
-source = "git+https://github.com/bloodfeast/rs_physics#6219384de7da50a5f812f8b47595b3fea80dd111"
+version = "0.2.0"
+source = "git+https://github.com/bloodfeast/rs_physics?branch=feature-add-cosmological-particle-sim#f356553d8785d42ec3634c9f69c25a8b5850ee3f"
 dependencies = [
+ "approx",
  "env_logger",
  "log",
  "rand 0.9.0",
@@ -3620,7 +3619,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3629,9 +3628,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rustybuzz"
@@ -3639,7 +3638,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "bytemuck",
  "libm",
  "smallvec",
@@ -3661,9 +3660,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3714,9 +3713,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3794,7 +3793,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3828,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3922,9 +3921,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4063,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "typeid"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-bidi"
@@ -4087,9 +4086,9 @@ checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4310,7 +4309,7 @@ checksum = "d63c3c478de8e7e01786479919c8769f62a22eec16788d8c2ac77ce2c132778a"
 dependencies = [
  "arrayvec",
  "bit-vec 0.8.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg_aliases 0.1.1",
  "document-features",
  "indexmap",
@@ -4337,7 +4336,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set 0.8.0",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block",
  "bytemuck",
  "cfg_aliases 0.1.1",
@@ -4378,7 +4377,7 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610f6ff27778148c31093f3b03abc4840f9636d58d597ca2f5977433acfe0068"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "js-sys",
  "web-sys",
 ]
@@ -4897,7 +4896,7 @@ checksum = "a809eacf18c8eca8b6635091543f02a5a06ddf3dad846398795460e6e0ae3cc0"
 dependencies = [
  "android-activity",
  "atomic-waker",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "block2",
  "bytemuck",
  "calloop",
@@ -4948,7 +4947,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4989,7 +4988,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "dlib",
  "log",
  "once_cell",
@@ -5032,11 +5031,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+checksum = "09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872"
 dependencies = [
- "zerocopy-derive 0.8.20",
+ "zerocopy-derive 0.8.22",
 ]
 
 [[package]]
@@ -5052,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+checksum = "79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,9 +1858,9 @@ checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encase"
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -3393,7 +3393,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.22",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3598,9 +3598,8 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 [[package]]
 name = "rs_physics"
 version = "0.2.0"
-source = "git+https://github.com/bloodfeast/rs_physics?branch=feature-add-cosmological-particle-sim#f356553d8785d42ec3634c9f69c25a8b5850ee3f"
+source = "git+https://github.com/bloodfeast/rs_physics?branch=nightly#151c760a5d40f583bcddc77b9eccd4e6e28c2ab7"
 dependencies = [
- "approx",
  "env_logger",
  "log",
  "rand 0.9.0",
@@ -5031,11 +5030,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09612fda0b63f7cb9e0af7e5916fe5a1f8cdcb066829f10f36883207628a4872"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.22",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -5051,9 +5050,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f81d38d7a2ed52d8f034e62c568e111df9bf8aba2f7cf19ddc5bf7bd89d520"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15"
-rs_physics = { git = "https://github.com/bloodfeast/rs_physics", features = ["all"], branch = "feature-add-cosmological-particle-sim" }
+rs_physics = { git = "https://github.com/bloodfeast/rs_physics", features = ["all"], branch = "nightly" }
 rand = "0.9.0"
 rayon = "1.10.0"
 bumpalo = "3.17.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy = "0.15"
-rs_physics = { git = "https://github.com/bloodfeast/rs_physics", features = ["all"] }
+rs_physics = { git = "https://github.com/bloodfeast/rs_physics", features = ["all"], branch = "feature-add-cosmological-particle-sim" }
 rand = "0.9.0"
 rayon = "1.10.0"
 bumpalo = "3.17.0"

--- a/src/actors/enemy.rs
+++ b/src/actors/enemy.rs
@@ -50,8 +50,10 @@ pub fn spawn_enemy(
     let spawn_x_position = rand::random_range((player_transform.translation.x - 800.0).max(-800.0)..=(player_transform.translation.x + 800.0).min(1200.0));
     let spawn_y_position = rand::random_range(player_transform.translation.y + 600.0..=player_transform.translation.y + 800.0);
     let initial_velocity = rand::random_range(200.0..=400.0);
-    // Enemy
-    let mut enemy_object = ObjectIn2D::new(1.0, initial_velocity, (0.0, -1.0), (spawn_x_position as f64, spawn_y_position as f64));
+
+    // Enemy - Updated to use the new directional velocities API
+    // Since the enemy moves straight down, we set vx=0 and vy=-initial_velocity
+    let enemy_object = ObjectIn2D::new(1.0, 0.0, -initial_velocity, (spawn_x_position as f64, spawn_y_position as f64));
     let enemy_color = Color::srgb(1.0, 0.25, 0.25);
 
     let enemy_mesh = Circle::new(3.14);

--- a/src/actors/particles.rs
+++ b/src/actors/particles.rs
@@ -2,9 +2,12 @@
 
 use std::ops::DerefMut;
 use std::sync::atomic::AtomicPtr;
+use std::time::Duration;
 use bevy::log::tracing_subscriber::fmt::time;
 use bevy::prelude::*;
 use bevy::sprite::Anchor;
+use bevy::utils::hashbrown::Equivalent;
+use bevy::utils::HashMap;
 use rand::random as rand_random;
 use rayon::prelude::*;
 use rs_physics::particles::{
@@ -13,8 +16,7 @@ use rs_physics::particles::{
 use rs_physics::particles::particle_interactions_barnes_hut_cosmological;
 use rs_physics::utils::{DEFAULT_PHYSICS_CONSTANTS, PhysicsConstants};
 
-// Use the standard Barnes-Hut implementation which is more performant
-// Our models will bridge between the two implementations
+const TIME_STEP_MODIFIERS: [f64; 4] = [0.16, 0.1, 0.064, 0.016];
 
 // Convert from cosmological Particle to standard ParticleData
 fn convert_to_particle_data(p: &particle_interactions_barnes_hut_cosmological::Particle) -> ParticleData {
@@ -89,18 +91,86 @@ impl CosmologicalSimulation {
         }
     }
 
+    pub fn optimize_for_orbits(&mut self) {
+        // Group particles by proximity to massive bodies
+        let massive_indices: Vec<usize> = self.particles.iter()
+            .enumerate()
+            .filter(|(_, p)| p.mass > 1000.0)
+            .map(|(i, _)| i)
+            .collect();
+
+        // Pre-compute orbital zones for massive particles
+        let orbital_zones: Vec<(f64, f64, f64)> = massive_indices.iter()
+            .map(|&i| {
+                let p = &self.particles[i];
+                // Return position and influence radius based on mass
+                (p.position.0, p.position.1, p.mass.sqrt() * 0.2)
+            })
+            .collect();
+
+        // Tag particles that are in orbital zones
+        // This could be used to optimize force calculations
+        for (i, p) in self.particles.iter_mut().enumerate() {
+            let mut in_orbit = false;
+
+            for &(center_x, center_y, radius) in &orbital_zones {
+                let dx = p.position.0 - center_x;
+                let dy = p.position.1 - center_y;
+                let dist = (dx * dx + dy * dy).sqrt();
+
+                if dist < radius && p.mass < 100.0 {
+                    // This particle is in an orbital zone
+                    in_orbit = true;
+                    break;
+                }
+            }
+
+            // You could use this flag to apply special physics/rendering
+            // to particles in orbital zones
+            if in_orbit {
+                // Example: Adjust particle color to indicate it's in orbit
+                p.density = p.density.max(0.8);  // Increase density parameter used for coloring
+            }
+        }
+    }
+
     pub fn step(&mut self) {
         // Use the standard (more performant) Barnes-Hut implementation
         // First, build the Barnes-Hut tree with standard particles
         let tree = build_tree(&self.standard_particles, self.standard_bounds);
 
-        // Calculate forces and update particles in parallel
-        let forces: Vec<(f64, f64)> = self.standard_particles.par_iter()
-            .map(|p| compute_net_force(&tree, *p, self.theta, self.g))
+        let orbital_factors: Vec<f64> = self.standard_particles.iter()
+            .map(|p| (p.mass / 1000.0).min(10.0).max(0.1))
             .collect();
+
 
         let a_ptr_mut = AtomicPtr::new(self);
         let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
+
+        let forces: Vec<(f64, f64)> = self.standard_particles.par_iter()
+            .enumerate()
+            .map(|(i, p)| {
+                let (fx, fy) = compute_net_force(&tree, *p, self.theta, self.g);
+
+                // Calculate perpendicular force component for orbital motion
+                // This creates a small tangential force to encourage stable orbits
+                let dist_sq = p.x * p.x + p.y * p.y;
+                let dist = dist_sq.sqrt();
+
+                // Only apply orbital adjustment to smaller particles
+                if p.mass < 1000.0 && dist > 0.1 {
+                    // Create perpendicular force vector (rotate 90 degrees)
+                    let orbital_strength = 0.75 * orbital_factors[i];  // Adjust this multiplier
+                    let perpendicular_fx = -fy * orbital_strength;
+                    let perpendicular_fy = fx * orbital_strength;
+
+                    (fx + perpendicular_fx, fy + perpendicular_fy)
+                } else {
+                    (fx, fy)
+                }
+            })
+            .collect();
+
         // Update our cosmological particles with the computed forces
         a_ptr.particles
             .par_iter_mut()
@@ -114,11 +184,25 @@ impl CosmologicalSimulation {
                 // Apply force to update velocity
                 p.apply_force(fx, fy, self.dt);
 
-                // add drag force to slow down particles
-                let drag_force = p.velocity.magnitude().log(1.089) * 0.1;
+                let vel_magnitude = p.velocity.magnitude();
+                let optimal_orbit_speed = (p.mass / 1000.0).sqrt() * 0.2; // Scale with particle mass
+                let speed_diff = (vel_magnitude - optimal_orbit_speed).abs();
+
+                // Apply drag that pushes velocity toward optimal orbital speed
+                let drag_strength = if vel_magnitude > optimal_orbit_speed {
+                    // Slow down faster particles
+                    speed_diff * 0.015
+                } else if vel_magnitude < optimal_orbit_speed * 0.314 {
+                    // Speed up very slow particles
+                    -speed_diff * 0.05
+                } else {
+                    // Minimal drag in the "orbital zone"
+                    speed_diff * 0.001
+                };
+
                 let drag_angle = p.velocity.direction();
-                let drag_fx = -drag_force * drag_angle.x;
-                let drag_fy = -drag_force * drag_angle.y;
+                let drag_fx = -drag_strength * drag_angle.x;
+                let drag_fy = -drag_strength * drag_angle.y;
 
                 // Apply drag force
                 p.apply_force(drag_fx, drag_fy, self.dt);
@@ -158,24 +242,37 @@ impl CosmologicalSimulation {
 
     pub fn modify_particle_masses(&mut self) {
         // Process in chunks to avoid excessive memory usage
-        let chunk_size = 4_096;
-
+        let chunk_size = 8_192;
         let a_ptr_mut = AtomicPtr::new(self);
 
         for chunk_start in (0..self.particles.len()).step_by(chunk_size) {
             let chunk_end = (chunk_start + chunk_size).min(self.particles.len());
 
             (chunk_start..chunk_end).into_par_iter().for_each(|i| {
-                // Create some super massive particles
-                let extra_dense = rand_random::<f64>() < 1.0/128.0;
-                let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
-                if extra_dense {
-                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(2400.0, 360.0);
-                    a_ptr.particles[i].spin *= 50.0; // Increase spin for massive particles
+                let a_ptr = unsafe { &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
 
-                    // Update standard particle mass to match
-                    a_ptr.standard_particles[i].mass = a_ptr.particles[i].mass;
+                // Create a more diverse mass distribution
+                let mass_type = rand_random::<f64>();
+
+                if mass_type < 0.001 {
+                    // Super massive "suns" (0.1% of particles)
+                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(5000.0, 2000.0);
+                    a_ptr.particles[i].spin *= 20.0;
+                } else if mass_type < 0.01 {
+                    // Medium "planets" (0.9% of particles)
+                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(500.0, 100.0);
+                    a_ptr.particles[i].spin *= 10.0;
+                } else if mass_type < 0.1 {
+                    // Small "asteroids" (9% of particles)
+                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(50.0, 20.0);
+                    a_ptr.particles[i].spin *= 5.0;
+                } else {
+                    // Tiny "dust" (90% of particles)
+                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(10.0, 1.0);
                 }
+
+                // Update standard particle mass to match
+                a_ptr.standard_particles[i].mass = a_ptr.particles[i].mass;
             });
         }
     }
@@ -210,7 +307,7 @@ impl CosmologicalSimulation {
                 p.velocity.x = new_x * current_speed;
                 p.velocity.y = new_y * current_speed;
             });
-        }
+        };
     }
 
     pub fn get_particles(&self) -> &[particle_interactions_barnes_hut_cosmological::Particle] {
@@ -228,10 +325,10 @@ pub fn setup(
     time: Res<Time<Fixed>>,
 ) {
     // Initialize simulation parameters with reduced particle count
-    let num_particles = 48_000;  // Reduced from 128,000 to improve initial loading
-    let initial_radius = 2.0 * std::f64::consts::PI.ln_1p();
-    let dt = time.timestep().as_secs_f64() * 0.064;
-    let theta = 0.5;  // Increased from 0.5 for better approximation/performance balance
+    let num_particles = 46_000;  // Reduced from 128,000 to improve initial loading
+    let initial_radius = 25.0 * std::f64::consts::PI.ln_1p();
+    let dt = time.timestep().as_secs_f64() * TIME_STEP_MODIFIERS[0];
+    let theta = 0.85;  // Increased from 0.5 for better approximation/performance balance
     let g = 1.0 / std::f64::consts::PI;  // Gravitational constant
 
     // Create the simulation
@@ -249,9 +346,12 @@ pub fn setup(
     // Add some randomness to initial directions
     simulation.randomize_particle_directions();
 
+    simulation.optimize_for_orbits();
+
     // Add the simulation as a resource
     commands.insert_resource(simulation);
 }
+
 
 #[derive(Component)]
 pub struct ParticleId(usize);
@@ -260,6 +360,8 @@ pub fn update_simulation(
     mut sim_res: ResMut<CosmologicalSimulation>,
     mut query: Query<(&mut Transform, &mut Visibility, &ParticleId)>,
 ) {
+
+
     // Advance the simulation one time step
     sim_res.step();
 
@@ -267,7 +369,7 @@ pub fn update_simulation(
     let particles = sim_res.get_particles();
 
     // Define batch size for processing entities
-    let batch_size = 4_096;
+    let batch_size = 8_192;
 
     let visible_radius = 1440.0_f64;
     // Use batched processing to reduce memory pressure
@@ -276,12 +378,22 @@ pub fn update_simulation(
         batch.par_iter_mut().for_each(|(ref mut transform,ref mut visibility,  particle_id)| {
             let particle = &particles[particle_id.0];
 
+            if visibility.eq(&Visibility::Hidden) {
+                return;
+            }
+
             // Check if particle is worth rendering
             if particle.position.0.powi(2) + particle.position.1.powi(2) > visible_radius.powi(2) {
                 // Make invisible to skip rendering
-                transform.scale = Vec3::ZERO;
+                visibility.toggle_visible_hidden();
+
                 return;
             }
+
+
+            // Scale based on mass and density for visual effect
+            let scale_factor = (particle.mass.log10() * 0.75).max(1.0).min(10.0) as f32;
+
             // Update position
             transform.translation = Vec3::new(
                 particle.position.0 as f32,
@@ -292,11 +404,11 @@ pub fn update_simulation(
             // Update rotation based on particle direction and spin
             let direction = particle.velocity.direction();
             let rotation_angle = direction.x.atan2(direction.y) as f32;
-            transform.rotation = Quat::from_rotation_z(rotation_angle + (particle.spin as f32 * 0.1));
+            transform.rotation = Quat::from_rotation_z(rotation_angle + (particle.spin as f32 * 0.75));
 
-            // Scale based on mass and density for visual effect
-            let scale_factor = (particle.mass.log10() * 0.5).max(5.0).min(1.0) as f32;
+            // Regular circular scale for larger particles
             transform.scale = Vec3::splat(scale_factor);
+
         });
     }
 }
@@ -309,7 +421,7 @@ pub fn spawn_particles(
     let particle_count = sim_res.get_particle_count();
 
     // Use batch spawning to reduce memory pressure
-    let batch_size = 4_096;
+    let batch_size = 8_192;
 
     for batch_start in (0..particle_count).step_by(batch_size) {
         let batch_end = (batch_start + batch_size).min(particle_count);
@@ -319,16 +431,16 @@ pub fn spawn_particles(
 
             // Calculate color based on particle properties
             let hue = 360.0 * (i as f32 / particle_count as f32);
-            let saturation = (particle.density as f32 * 0.5).clamp(0.45, 1.0);
-            let lightness = ((particle.age as f32 * 0.01) + 0.5).clamp(0.25, 1.0);
+            let saturation = (particle.density as f32 * 0.5).clamp(0.35, 0.65);
+            let lightness = ((particle.age as f32 * 0.01) + 0.5).clamp(0.65, 1.0);
             let color = Color::hsl(hue, saturation, lightness);
 
             // Initial position
-            let x = particle.position.0 as f32 + rand::random_range(-1.0..=1.0);
-            let y = particle.position.1 as f32 + rand::random_range(-1.0..=1.0);
+            let x = particle.position.0 as f32;
+            let y = particle.position.1 as f32;
 
             // Initial scale based on mass
-            let scale = (particle.mass.log10() * 0.85).max(5.0).min(1.0) as f32;
+            let scale = (particle.mass.log10() * 0.85).max(1.0).min(6.0) as f32;
 
             commands.spawn((
                 Sprite {

--- a/src/actors/particles.rs
+++ b/src/actors/particles.rs
@@ -1,173 +1,349 @@
+// Add this to particles.rs to immediately improve performance
+
 use std::ops::DerefMut;
 use std::sync::atomic::AtomicPtr;
-use std::sync::Mutex;
-use bevy::asset::AssetContainer;
+use bevy::log::tracing_subscriber::fmt::time;
 use bevy::prelude::*;
 use bevy::sprite::Anchor;
-use rs_physics::particles::{build_tree, compute_net_force, ParticleData, Quad, Simulation};
-use rs_physics::utils::{DEFAULT_PHYSICS_CONSTANTS, PhysicsConstants};
+use rand::random as rand_random;
 use rayon::prelude::*;
+use rs_physics::particles::{
+    ParticleData, Quad, build_tree, compute_net_force
+};
+use rs_physics::particles::particle_interactions_barnes_hut_cosmological;
+use rs_physics::utils::{DEFAULT_PHYSICS_CONSTANTS, PhysicsConstants};
+
+// Use the standard Barnes-Hut implementation which is more performant
+// Our models will bridge between the two implementations
+
+// Convert from cosmological Particle to standard ParticleData
+fn convert_to_particle_data(p: &particle_interactions_barnes_hut_cosmological::Particle) -> ParticleData {
+    ParticleData {
+        x: p.position.0,
+        y: p.position.1,
+        mass: p.mass
+    }
+}
+
+// Convert from standard Quad to cosmological Quad
+fn convert_quad(q: &Quad) -> particle_interactions_barnes_hut_cosmological::Quad {
+    particle_interactions_barnes_hut_cosmological::Quad {
+        cx: q.cx,
+        cy: q.cy,
+        half_size: q.half_size
+    }
+}
 
 #[derive(Resource)]
-pub struct PhysicsSim(Simulation);
+pub struct CosmologicalSimulation {
+    particles: Vec<particle_interactions_barnes_hut_cosmological::Particle>,
+    standard_particles: Vec<ParticleData>, // Add this for efficient computation
+    bounds: particle_interactions_barnes_hut_cosmological::Quad,
+    standard_bounds: Quad, // Add this for efficient computation 
+    time: f64,
+    dt: f64,
+    theta: f64,
+    g: f64,
+    initial_radius: f64,
+}
 
+impl CosmologicalSimulation {
+    pub fn new(
+        num_particles: usize,
+        initial_radius: f64,
+        dt: f64,
+        theta: f64,
+        g: f64
+    ) -> Self {
+        // Create bounding quad that encompasses the simulation area
+        let bounds = particle_interactions_barnes_hut_cosmological::Quad {
+            cx: 0.0,
+            cy: 0.0,
+            half_size: initial_radius * 100.0  // Add some buffer around the simulation
+        };
+
+        let standard_bounds = Quad {
+            cx: 0.0,
+            cy: 0.0,
+            half_size: initial_radius * 80.0
+        };
+
+        // Create particles in a Big Bang configuration
+        let particles = particle_interactions_barnes_hut_cosmological::create_big_bang_particles(num_particles, initial_radius);
+
+        // Create standard particles as well
+        let standard_particles: Vec<ParticleData> = particles.iter()
+            .map(|p| convert_to_particle_data(p))
+            .collect();
+
+        Self {
+            particles,
+            standard_particles,
+            bounds,
+            standard_bounds,
+            time: 0.0,
+            dt,
+            theta,
+            g,
+            initial_radius,
+        }
+    }
+
+    pub fn step(&mut self) {
+        // Use the standard (more performant) Barnes-Hut implementation
+        // First, build the Barnes-Hut tree with standard particles
+        let tree = build_tree(&self.standard_particles, self.standard_bounds);
+
+        // Calculate forces and update particles in parallel
+        let forces: Vec<(f64, f64)> = self.standard_particles.par_iter()
+            .map(|p| compute_net_force(&tree, *p, self.theta, self.g))
+            .collect();
+
+        let a_ptr_mut = AtomicPtr::new(self);
+        let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
+        // Update our cosmological particles with the computed forces
+        a_ptr.particles
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(i, p)| {
+
+                let (fx, fy) = forces[i];
+
+
+
+                // Apply force to update velocity
+                p.apply_force(fx, fy, self.dt);
+
+                // add drag force to slow down particles
+                let drag_force = p.velocity.magnitude().log(1.089) * 0.1;
+                let drag_angle = p.velocity.direction();
+                let drag_fx = -drag_force * drag_angle.x;
+                let drag_fy = -drag_force * drag_angle.y;
+
+                // Apply drag force
+                p.apply_force(drag_fx, drag_fy, self.dt);
+
+                // Update position
+                p.update_position(self.dt);
+
+                // commented out for performance and cause it looks cooler
+                //self.apply_boundary_conditions(p);
+
+                let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
+
+                // Update the standard particle to stay in sync
+                a_ptr.standard_particles[i].x = p.position.0;
+                a_ptr.standard_particles[i].y = p.position.1;
+        });
+
+        self.time += self.dt;
+    }
+
+    pub fn apply_boundary_conditions(&self, p: &mut particle_interactions_barnes_hut_cosmological::Particle) {
+        let bound_size = self.bounds.half_size * 4.0;
+
+        // Periodic boundary conditions (wraparound)
+        if p.position.0 < self.bounds.cx - self.bounds.half_size {
+            p.position.0 += bound_size;
+        } else if p.position.0 >= self.bounds.cx + self.bounds.half_size {
+            p.position.0 -= bound_size;
+        }
+
+        if p.position.1 < self.bounds.cy - self.bounds.half_size {
+            p.position.1 += bound_size;
+        } else if p.position.1 >= self.bounds.cy + self.bounds.half_size {
+            p.position.1 -= bound_size;
+        }
+    }
+
+    pub fn modify_particle_masses(&mut self) {
+        // Process in chunks to avoid excessive memory usage
+        let chunk_size = 4_096;
+
+        let a_ptr_mut = AtomicPtr::new(self);
+
+        for chunk_start in (0..self.particles.len()).step_by(chunk_size) {
+            let chunk_end = (chunk_start + chunk_size).min(self.particles.len());
+
+            (chunk_start..chunk_end).into_par_iter().for_each(|i| {
+                // Create some super massive particles
+                let extra_dense = rand_random::<f64>() < 1.0/128.0;
+                let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
+                if extra_dense {
+                    a_ptr.particles[i].mass = std::f64::consts::PI * rand_random::<f64>().mul_add(2400.0, 360.0);
+                    a_ptr.particles[i].spin *= 50.0; // Increase spin for massive particles
+
+                    // Update standard particle mass to match
+                    a_ptr.standard_particles[i].mass = a_ptr.particles[i].mass;
+                }
+            });
+        }
+    }
+
+    pub fn randomize_particle_directions(&mut self) {
+        // Process in chunks to avoid excessive memory usage
+        let chunk_size = 4_096;
+
+        let a_ptr_mut = AtomicPtr::new(self);
+        for chunk_start in (0..self.particles.len()).step_by(chunk_size) {
+            let chunk_end = (chunk_start + chunk_size).min(self.particles.len());
+
+            (chunk_start..chunk_end).into_par_iter().for_each(|i| {
+                let a_ptr = unsafe{ &mut *a_ptr_mut.load(std::sync::atomic::Ordering::Relaxed) };
+                let p = &mut a_ptr.particles[i];
+                let angle_variation = rand_random::<f64>().mul_add(0.5, -0.5) * std::f64::consts::PI;
+                let current_speed = p.velocity.magnitude();
+
+                let current_dir = if current_speed > 0.0 {
+                    (p.velocity.x / current_speed, p.velocity.y / current_speed)
+                } else {
+                    (0.0, 0.0)
+                };
+
+                // Rotate the direction by a random angle
+                let cos_angle = angle_variation.cos();
+                let sin_angle = angle_variation.sin();
+                let new_x = current_dir.0 * cos_angle - current_dir.1 * sin_angle;
+                let new_y = current_dir.0 * sin_angle + current_dir.1 * cos_angle;
+
+                // Update velocity with new direction but maintain speed
+                p.velocity.x = new_x * current_speed;
+                p.velocity.y = new_y * current_speed;
+            });
+        }
+    }
+
+    pub fn get_particles(&self) -> &[particle_interactions_barnes_hut_cosmological::Particle] {
+        &self.particles
+    }
+
+    pub fn get_particle_count(&self) -> usize {
+        self.particles.len()
+    }
+}
+
+// Reduced particle count for setup phase
 pub fn setup(
     mut commands: Commands,
     time: Res<Time<Fixed>>,
 ) {
-    // Initialize physics constants and simulation parameters
-    let constants = PhysicsConstants {
-        gravity: 0.0,
-        air_density: 0.0,
-        ..DEFAULT_PHYSICS_CONSTANTS
-    };
+    // Initialize simulation parameters with reduced particle count
+    let num_particles = 48_000;  // Reduced from 128,000 to improve initial loading
+    let initial_radius = 2.0 * std::f64::consts::PI.ln_1p();
+    let dt = time.timestep().as_secs_f64() * 0.064;
+    let theta = 0.5;  // Increased from 0.5 for better approximation/performance balance
+    let g = 1.0 / std::f64::consts::PI;  // Gravitational constant
 
-    let mut sim = Simulation::new(
-        128_000,               // number of particles
-        (0.0, 0.0),         // initial position
-        -486.,               // initial speed
-        (0.0, 0.25),         // initial direction
-        std::f64::consts::PI * rand::random_range(10.0..=60.0),                // mass
-        constants,
-        time.timestep().as_secs_f64(),              // time step (0.0016 is essentially slowing down the simulation, ~0.16 looks more natural imo) but this creates that cool 'big bang' effect
-    )
-        .expect("Failed to create simulation");
+    // Create the simulation
+    let mut simulation = CosmologicalSimulation::new(
+        num_particles,
+        initial_radius,
+        dt,
+        theta,
+        g
+    );
 
+    // Modify some particles to have more mass
+    simulation.modify_particle_masses();
 
-    sim.masses.par_iter_mut()
-        .enumerate()
-        .for_each(|(i, m)| {
-            let extra_dense = rand::random_bool(0.0314);
-            if extra_dense {
-                *m = std::f64::consts::PI * rand::random_range(64.0..128.0);
-            }
-        });
+    // Add some randomness to initial directions
+    simulation.randomize_particle_directions();
 
-    sim.directions_x.par_iter_mut()
-        .for_each(|x|
-            *x = rand::random_range(-0.25..0.25) * std::f64::consts::PI
-        );
-    sim.directions_y.par_iter_mut()
-        .for_each(|y|
-            *y = rand::random_range(-0.25..0.25) * std::f64::consts::PI
-        );
-
-    let physics_sim = PhysicsSim(sim);
-    commands.insert_resource(physics_sim);
-
-    // Optionally, spawn Bevy entities for visualization
+    // Add the simulation as a resource
+    commands.insert_resource(simulation);
 }
 
 #[derive(Component)]
 pub struct ParticleId(usize);
 
 pub fn update_simulation(
-    mut sim_res: ResMut<PhysicsSim>,
-    mut query: Query<(&mut Transform, &ParticleId)>,
+    mut sim_res: ResMut<CosmologicalSimulation>,
+    mut query: Query<(&mut Transform, &mut Visibility, &ParticleId)>,
 ) {
     // Advance the simulation one time step
-    sim_res.0.step().expect("Simulation step failed");
+    sim_res.step();
 
-    // Update each entity’s transform using the simulation’s positions.
-    query.par_iter_mut()
-        .for_each(|(mut transform, particle_id)| {
-            let x = sim_res.0.positions_x[particle_id.0];
-            let y = sim_res.0.positions_y[particle_id.0];
-            transform.translation = Vec3::new(x as f32, y as f32, -2.0);
-            transform.rotation = Quat::from_rotation_y((sim_res.0.directions_x[particle_id.0] as f32 * sim_res.0.directions_y[particle_id.0] as f32) * 1./std::f32::consts::PI);
-        });
-}
+    // Get particle data for rendering
+    let particles = sim_res.get_particles();
 
-pub fn update_forces(
-    mut sim_res: ResMut<PhysicsSim>,
-) {
-    // 1. Convert simulation arrays into a Vec<ParticleData>
-    let particle_count = sim_res.0.positions_x.len();
-    let particles: Vec<ParticleData> = (0..particle_count)
-        .into_par_iter()
-        .map(|i| ParticleData {
-            x: sim_res.0.positions_x[i],
-            y: sim_res.0.positions_y[i],
-            mass: sim_res.0.masses[i],
-        })
-        .collect();
+    // Define batch size for processing entities
+    let batch_size = 4_096;
 
-    // 2. Define a quad that bounds the simulation (adjust as needed)
-    let bounding_quad = Quad { cx: 0.0, cy: 0.0, half_size: (800. * std::f64::consts::PI) / (600. * std::f64::consts::PI)};
+    let visible_radius = 1440.0_f64;
+    // Use batched processing to reduce memory pressure
+    let mut items = query.iter_mut().collect::<Vec<_>>();
+    for batch in items.chunks_mut(batch_size) {
+        batch.par_iter_mut().for_each(|(ref mut transform,ref mut visibility,  particle_id)| {
+            let particle = &particles[particle_id.0];
 
-    // 3. Build the Barnes–Hut tree
-    let tree = build_tree(&particles, bounding_quad);
-
-    // Barnes–Hut parameters
-    let theta = 3.14; // controls approximation accuracy
-    let g = 1. / std::f64::consts::PI;
-
-    let mut ptr_sim_res = AtomicPtr::new(sim_res.deref_mut());
-
-    // 4. For each particle, compute net force and update velocity/position.
-    (0..particle_count)
-        .into_par_iter()
-        .for_each(|i| {
-            // This works here for 3 reasons (as I understand it, please correct me if I'm wrong):
-            // 1. the simulation resource is never dropped
-            // 2. we are never changing the resource itself, only the data it points to
-            // 3. the data that is being changed is not being accessed by any other thread at the same time
-            let sim_res = unsafe { &mut *ptr_sim_res.load(std::sync::atomic::Ordering::Relaxed) };
-            let p = ParticleData {
-                x: sim_res.0.positions_x[i],
-                y: sim_res.0.positions_y[i],
-                mass: sim_res.0.masses[i],
-            };
-
-            // Compute the net force from the Barnes–Hut tree.
-            let (force_x, force_y) = compute_net_force(&tree, p, theta, g);
-
-            // Compute acceleration: a = F / m.
-            let ax = force_x / p.mass;
-            let ay = force_y / p.mass;
-
-            // Recover the current velocity components.
-            let vx = sim_res.0.speeds[i] * sim_res.0.directions_x[i];
-            let vy = sim_res.0.speeds[i] * sim_res.0.directions_y[i];
-
-            // Update velocity with acceleration.
-            let new_vx = vx + ax * sim_res.0.dt;
-            let new_vy = vy + ay * sim_res.0.dt;
-
-            // Recompute speed and normalize direction.
-            let new_speed = ((new_vx * new_vx) + (new_vy * new_vy)).sqrt().log(g);
-            sim_res.0.speeds[i] = new_speed;
-            if new_speed != 0.0 {
-                sim_res.0.directions_x[i] = new_vx / new_speed;
-                sim_res.0.directions_y[i] = new_vy / new_speed;
+            // Check if particle is worth rendering
+            if particle.position.0.powi(2) + particle.position.1.powi(2) > visible_radius.powi(2) {
+                // Make invisible to skip rendering
+                transform.scale = Vec3::ZERO;
+                return;
             }
+            // Update position
+            transform.translation = Vec3::new(
+                particle.position.0 as f32,
+                particle.position.1 as f32,
+                -2.0
+            );
 
-            // Update position based on the new velocity.
-            sim_res.0.positions_x[i] += new_vx * sim_res.0.dt;
-            sim_res.0.positions_y[i] += new_vy * sim_res.0.dt;
+            // Update rotation based on particle direction and spin
+            let direction = particle.velocity.direction();
+            let rotation_angle = direction.x.atan2(direction.y) as f32;
+            transform.rotation = Quat::from_rotation_z(rotation_angle + (particle.spin as f32 * 0.1));
+
+            // Scale based on mass and density for visual effect
+            let scale_factor = (particle.mass.log10() * 0.5).max(5.0).min(1.0) as f32;
+            transform.scale = Vec3::splat(scale_factor);
         });
+    }
 }
 
 pub fn spawn_particles(
     mut commands: Commands,
-    sim_res: Res<PhysicsSim>,
+    sim_res: Res<CosmologicalSimulation>,
 ) {
-    let particle_count = sim_res.0.positions_x.len();
-    for i in 0..particle_count {
-        let color = Color::hsl(360. * i as f32 / particle_count as f32, rand::random_range(0.45..=1.0), rand::random_range(0.5..=1.0));
-        let x = sim_res.0.positions_x[i] as f32;
-        let y = sim_res.0.positions_y[i] as f32;
-        commands.spawn((
-            Sprite {
-                color,
-                custom_size: Some(Vec2::new(1.0, 1.0)),
-                anchor: Anchor::Center,
-                ..Default::default()
-            },
-            Transform {
-                translation: Vec3::new(x, y, -2.0),
-                ..Default::default()
-            },
-        )).insert(ParticleId(i));
+    let particles = sim_res.get_particles();
+    let particle_count = sim_res.get_particle_count();
+
+    // Use batch spawning to reduce memory pressure
+    let batch_size = 4_096;
+
+    for batch_start in (0..particle_count).step_by(batch_size) {
+        let batch_end = (batch_start + batch_size).min(particle_count);
+
+        for i in batch_start..batch_end {
+            let particle = &particles[i];
+
+            // Calculate color based on particle properties
+            let hue = 360.0 * (i as f32 / particle_count as f32);
+            let saturation = (particle.density as f32 * 0.5).clamp(0.45, 1.0);
+            let lightness = ((particle.age as f32 * 0.01) + 0.5).clamp(0.25, 1.0);
+            let color = Color::hsl(hue, saturation, lightness);
+
+            // Initial position
+            let x = particle.position.0 as f32 + rand::random_range(-1.0..=1.0);
+            let y = particle.position.1 as f32 + rand::random_range(-1.0..=1.0);
+
+            // Initial scale based on mass
+            let scale = (particle.mass.log10() * 0.85).max(5.0).min(1.0) as f32;
+
+            commands.spawn((
+                Sprite {
+                    color,
+                    custom_size: Some(Vec2::new(1.0, 1.0)),
+                    anchor: Anchor::Center,
+                    ..Default::default()
+                },
+                Transform {
+                    translation: Vec3::new(x, y, -2.0),
+                    scale: Vec3::splat(scale),
+                    ..Default::default()
+                },
+                ParticleId(i),
+            ));
+        }
     }
 }

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -246,7 +246,7 @@ pub fn player_input(
         }
 
         let player_phys_obj = physics_system.0.get_object_mut(0).unwrap();
-        if player_phys_obj.position.y <= calculate_ground_level(player_phys_obj.position.x) + 10.0 {
+        if player_phys_obj.position.y <= calculate_ground_level(player_phys_obj.position.x) + 5.0 {
             // Get the direction of movement from velocity components
             let direction = player_phys_obj.direction();
 
@@ -275,9 +275,6 @@ pub fn player_input(
 
     if keyboard_input.pressed(KeyCode::KeyA) {
         let player_phys_obj = physics_system.0.get_object_mut(0).unwrap();
-        if player_phys_obj.position.y > calculate_ground_level(player_phys_obj.position.x) + 5.0 {
-            return;
-        }
 
         // Calculate ground tangent for appropriate movement angle
         let tangent = ground_tangent(player_phys_obj.position.x as f32);
@@ -297,9 +294,6 @@ pub fn player_input(
 
     if keyboard_input.pressed(KeyCode::KeyD) {
         let player_phys_obj = physics_system.0.get_object_mut(0).unwrap();
-        if player_phys_obj.position.y > calculate_ground_level(player_phys_obj.position.x) + 5.0 {
-            return;
-        }
 
         let tangent = ground_tangent(player_phys_obj.position.x as f32);
         // Compute the angle from the tangent vector

--- a/src/actors/player.rs
+++ b/src/actors/player.rs
@@ -1,11 +1,13 @@
 use bevy::log::tracing_subscriber::fmt::time;
 use bevy::math::VectorSpace;
 use bevy::prelude::*;
+use bevy::render::view::prepare_windows;
 use bevy::sprite::Anchor;
 use bevy::tasks::futures_lite::StreamExt;
+use bevy::window::WindowRef;
 use rs_physics::forces::Force;
 use rs_physics::interactions::elastic_collision_2d;
-use rs_physics::models::ObjectIn2D;
+use rs_physics::models::{ObjectIn2D, Velocity2D};
 use rs_physics::utils::{DEFAULT_PHYSICS_CONSTANTS, PhysicsConstants};
 use crate::hud::{EnergyBar, HpBar, ShieldBar};
 use crate::state::MainGameState;
@@ -13,7 +15,7 @@ use crate::state::MainGameState;
 pub(crate) const GROUND_LEVEL: f64 = -300.0;
 
 const PHYSICS_CONSTANTS: PhysicsConstants = PhysicsConstants {
-    gravity: -DEFAULT_PHYSICS_CONSTANTS.gravity / 2.0,
+    gravity: DEFAULT_PHYSICS_CONSTANTS.gravity / 2.0,
     ground_level: GROUND_LEVEL,
     ..DEFAULT_PHYSICS_CONSTANTS
 };
@@ -29,27 +31,28 @@ impl PhysicsSystem2D {
         physics_system.apply_drag(0.47, 0.5);
         Self (physics_system)
     }
-
 }
 
 #[derive(Component)]
 pub struct Player;
 
-
-
-pub fn setup_player(
+pub fn setup_camera(
     mut commands: Commands,
-    mut meshes: ResMut<Assets<Mesh>>,
-    mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
     commands.spawn(
         Camera2d {
             ..default()
         }
     );
+}
 
-    // Player
-    let player_object = ObjectIn2D::new(65.0, 0.0, (0.0, 0.0), (-200.0, GROUND_LEVEL + 100.0));
+pub fn setup_player(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Player - updated to use the new ObjectIn2D::new with velocity components
+    let player_object = ObjectIn2D::new(65.0, 0.0, 0.0, (-200.0, GROUND_LEVEL + 100.0));
     let player_color = Color::srgb(0.5, 1.0, 0.5);
 
     commands
@@ -139,48 +142,54 @@ pub fn camera_movement(
 
     energy_bar_transform.translation.x = camera_transform.translation.x - 400.0;
     energy_bar_transform.translation.y = camera_transform.translation.y + 280.0;
-
 }
-
 
 pub fn player_movement_physics (
     mut player_transform_query: Query<&mut Transform, With<Player>>,
     mut player_query: Query<&mut PhysicsSystem2D>,
     time: Res<Time<Fixed>>,
 ) {
-
     let mut player_transform = player_transform_query.get_single_mut()
         .expect("There should only be one player entity");
     player_query
         .par_iter_mut()
         .for_each(|mut physics_system| {
-            physics_system.0.update( 0.62);
+            physics_system.0.update(0.62);
 
             let ground_level = calculate_ground_level(player_transform.translation.x as f64);
             physics_system.0.update_ground_level(ground_level);
 
             let player_obj = physics_system.0.get_object_mut(0).unwrap();
 
-            player_obj.velocity = player_obj.velocity * 0.98;
-            if player_obj.velocity.abs() < 1.0 {
-                player_obj.velocity = 0.0;
-                player_obj.direction.x = 0.0;
+            // Apply velocity damping - updated to work with velocity components
+            player_obj.velocity.x *= 0.98;
+            player_obj.velocity.y *= 0.98;
+
+            // Check if velocity is very small and zero it out if so
+            if player_obj.speed() < 1.0 {
+                player_obj.velocity.x = 0.0;
+                player_obj.velocity.y = 0.0;
             }
 
+            // Enforce position bounds
             if player_obj.position.x >= 1100.0 || player_obj.position.x <= -400.0 {
                 player_obj.position.x = player_obj.position.x.clamp(-400.0, 1100.0);
-                player_obj.direction.x = 0.0;
+                player_obj.velocity.x = 0.0;
             }
 
-            if player_obj.position.y <= ground_level + 10.0 && player_obj.direction.y < 0.0 {
-                let mut ground_object = ObjectIn2D::new(1e11, 0.0, (0.0, 0.0), (player_obj.position.x, ground_level));
-                // Now simulate an elastic collision between the player and the ground.
-                // The ground object is an immovable object with very high mass.
+            // Ground collision detection
+            if player_obj.position.y <= ground_level + 10.0 && player_obj.velocity.y < 0.0 {
+                // Create a ground object with very high mass (effectively immovable)
+                let mut ground_object = ObjectIn2D::new(1e11, 0.0, 0.0, (player_obj.position.x, ground_level));
+
+                // Determine collision angle based on terrain
                 let collision_angle = if player_transform.translation.x > 396.54 {
                     std::f64::consts::FRAC_PI_2 + std::f64::consts::FRAC_PI_8
                 } else {
                     std::f64::consts::FRAC_PI_2
                 };
+
+                // Simulate elastic collision with the ground
                 elastic_collision_2d(
                     &PHYSICS_CONSTANTS,
                     player_obj,
@@ -198,12 +207,9 @@ pub fn update_player_movement(
     mut player_transform_query: Query<&mut Transform, With<Player>>,
     mut player_query: Query<&mut PhysicsSystem2D>,
 ) {
-
     let mut player_transform = player_transform_query.get_single_mut()
         .expect("There should only be one player entity");
-    if let Ok(mut physics_system) =
-        player_query.get_single_mut() {
-
+    if let Ok(mut physics_system) = player_query.get_single_mut() {
         let player_obj = physics_system.0.get_object_mut(0).unwrap();
 
         player_transform.translation.x = player_obj.position.x as f32;
@@ -223,37 +229,38 @@ fn ground_tangent(x_pos: f32) -> (f32, f32) {
         (1.0, 0.0)
     }
 }
+
 pub fn player_input(
     keyboard_input: Res<ButtonInput<KeyCode>>,
     mut player_query: Query<&mut PhysicsSystem2D, With<Player>>,
     mut game_state: ResMut<MainGameState>,
     time: Res<Time>,
 ) {
-
     let mut physics_system = player_query.iter_mut()
-            .next()
-            .expect("There should only be one player entity");
+        .next()
+        .expect("There should only be one player entity");
 
     if keyboard_input.just_pressed(KeyCode::Space) {
         if game_state.player_energy <= 0.0 {
             return;
         }
+
         let player_phys_obj = physics_system.0.get_object_mut(0).unwrap();
         if player_phys_obj.position.y <= calculate_ground_level(player_phys_obj.position.x) + 10.0 {
+            // Get the direction of movement from velocity components
+            let direction = player_phys_obj.direction();
 
             let max_offset = std::f64::consts::FRAC_PI_6; // ~30 degrees
-            // Offset angle based on x direction (between -1.0 and 1.0 inclusive)
-            let angle_offset = player_phys_obj.direction.x * max_offset;
+            // Offset angle based on x direction
+            let angle_offset = direction.x * max_offset;
             // Subtract offset from π/2 so that if x > 0, jump tilts right (angle becomes < π/2)
             // and if x < 0, jump tilts left (angle becomes > π/2).
             let thrust_angle = std::f64::consts::FRAC_PI_2 - angle_offset;
             let base_magnitude = 9800.0;
-            // the only issue with this is that it takes away from the vertical thrust.
-            // this can be fixed by increasing the magnitude of the thrust.
-            // which is why the magnitude is doubled when x != 0.
-            // (this is less realistic, but it makes the movement feel better)
-            let magnitude = if player_phys_obj.direction.x.abs() != 0.0 {
-                base_magnitude * 2.0
+
+            // Adjust magnitude based on horizontal movement
+            let magnitude = if direction.x.abs() != 0.0 {
+                base_magnitude * 0.75
             } else {
                 base_magnitude
             };
@@ -265,22 +272,26 @@ pub fn player_input(
             game_state.player_energy = (game_state.player_energy - 25.0).max(0.0);
         }
     }
+
     if keyboard_input.pressed(KeyCode::KeyA) {
         let player_phys_obj = physics_system.0.get_object_mut(0).unwrap();
         if player_phys_obj.position.y > calculate_ground_level(player_phys_obj.position.x) + 5.0 {
             return;
         }
-        // todo: something is wrong with the tangent calculation or the angle but i honestly don't know what it is.
+
+        // Calculate ground tangent for appropriate movement angle
         let tangent = ground_tangent(player_phys_obj.position.x as f32);
-        // For leftward movement, reverse the tangent.
-        // Compute the angle from the left tangent vector.
+        // Compute the angle from the left tangent vector
         let angle = VectorSpace::lerp(tangent.1, tangent.0, time.delta_secs()).to_radians();
+
+        // Adjust force magnitude based on position
         let magnitude = if player_phys_obj.position.y >= calculate_ground_level(player_phys_obj.position.x) + 5.0 {
-            -200.0
+            -100.0
         } else {
-            -380.0
+            -280.0
         };
-        // Apply thrust along this angle.
+
+        // Apply thrust along this angle
         player_phys_obj.add_force(Force::Thrust { magnitude, angle: angle as f64 });
     }
 
@@ -289,16 +300,17 @@ pub fn player_input(
         if player_phys_obj.position.y > calculate_ground_level(player_phys_obj.position.x) + 5.0 {
             return;
         }
+
         let tangent = ground_tangent(player_phys_obj.position.x as f32);
-        // Compute the angle from the tangent vector.
-
+        // Compute the angle from the tangent vector
         let angle = VectorSpace::lerp(tangent.1, tangent.0, time.delta_secs()).to_radians();
-        let magnitude = if player_phys_obj.position.y >= calculate_ground_level(player_phys_obj.position.x) + 5.0 {
-            200.0
-        } else {
-            380.0
-        };
-        player_phys_obj.add_force(Force::Thrust { magnitude, angle: angle as f64 });
 
+        let magnitude = if player_phys_obj.position.y >= calculate_ground_level(player_phys_obj.position.x) + 5.0 {
+            100.0
+        } else {
+            280.0
+        };
+
+        player_phys_obj.add_force(Force::Thrust { magnitude, angle: angle as f64 });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,18 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(PreStartup, (hud::setup_hud, state::setup_game_state, actors::particles::setup))
-        .add_systems(Startup, actors::player::setup_player)
+        .add_systems(PreStartup, (
+            hud::setup_hud,
+            state::setup_game_state,
+            actors::particles::setup,
+        ))
+        .add_systems(Startup, (
+            actors::player::setup_camera,
+            actors::player::setup_player,
+        ))
         .add_systems(PostStartup, actors::particles::spawn_particles)
         .add_systems(FixedUpdate, (
             actors::enemy::spawn_enemy,
-            actors::particles::update_forces,
             state::refresh_player_energy,
             state::refresh_player_shield,
         ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ fn main() {
         .add_systems(Startup, (
             actors::player::setup_camera,
             actors::player::setup_player,
+            actors::particles::spawn_particles,
         ))
-        .add_systems(PostStartup, actors::particles::spawn_particles)
         .add_systems(FixedUpdate, (
             actors::enemy::spawn_enemy,
             state::refresh_player_energy,
@@ -26,8 +26,8 @@ fn main() {
         .add_systems(Update,(
             actors::enemy::update_enemy,
             actors::player::player_input,
-            actors::particles::update_simulation,
             actors::player::camera_movement,
+            actors::particles::update_simulation,
         ))
         .add_systems(PostUpdate, (actors::player::update_player_movement, hud::update_energy, hud::update_hp, hud::update_shield))
         .run();


### PR DESCRIPTION
There is now a 'nightly' build of rs_physics that makes use of avx-512 and some fallback SIMD instruction sets that are not available in stable
- Switched to nightly build of rs_physics
- Added orbital physics on particles
- reduced particle count to be more manageable with the enhanced physics calculations per particle